### PR TITLE
Fix an example in a tutorial for https-client

### DIFF
--- a/book/src/03_3_3_https_client.md
+++ b/book/src/03_3_3_https_client.md
@@ -11,7 +11,7 @@ cargo run --example https_client
 Create a custom client configuration to use an `esp_idf_svc::http::client::EspHttpConnection` which enables the use of these certificates and uses default values for everything else:
 
 ```rust
-let mut client = EspHttpClient::new(&EspHttpClientConfiguration {
+let connection = EspHttpConnection::new(&Configuration {
         use_global_ca_store: true,
         crt_bundle_attach: Some(esp_idf_sys::esp_crt_bundle_attach),
         ..Default::default()


### PR DESCRIPTION
It looks like this part of the tutorial wasn't updated when the example and crate were. This change should fix that.