### PR TITLE
fix typo

### DIFF
--- a/book/src/01_intro.md
+++ b/book/src/01_intro.md
@@ -10,7 +10,7 @@ The advanced course takes it from there to dive deeper into topics like interrup
 
 You can join the [esp-rs community](https://matrix.to/#/#esp-rs:matrix.org) on Matrix for all technical questions and issues! The community is open to everyone.
 
-## Translations
+## Translations
 
 This book has been translated by generous volunteers. If you would like your translation listed here, please open a PR to add it.
 

--- a/book/src/04_3_2_i2c.md
+++ b/book/src/04_3_2_i2c.md
@@ -94,7 +94,7 @@ where
 }
 ```
 
-✅ Implement a public method that reads the `WhoAmI` register with the address `0x0F`. Make use of the above `read_register()` method.
+✅ Implement a public method that reads the `WhoAmI` register with the address `0x75`. Make use of the above `read_register()` method.
 
 
 ✅ Optional: Implement further methods that add features to the driver. Check the [documentation](https://invensense.tdk.com/wp-content/uploads/2021/07/DS-000451-ICM-42670-P-v1.0.pdf) for the respective registers and their addresses. 💡 Some ideas:

--- a/book/src/04_3_3_i2c.md
+++ b/book/src/04_3_3_i2c.md
@@ -32,7 +32,7 @@ We're not going to write an entire driver, merely the first step: the `hello wor
 
 ### `read_register()` and `write_register()`
 
-✅ Check out the write and `write_read` function in the `embedded-hal`. Why is it `write_read` and not just `read`?
+✅ Check out the `write` and `write_read` function in the `embedded-hal`. Why is it `write_read` and not just `read`?
 
 <Details>
     <Summary>Answer</Summary>


### PR DESCRIPTION
- The character before "Translations" is not a normal space. It is U+00A0. This causes rendering issues:

![图片](https://github.com/esp-rs/std-training/assets/53737377/23ab81c7-6d8c-4ed5-85a6-91f32495e286)

- According to the context and datasheet, the address of the `WhoAmI` register should be 0x75.