### PR TITLE
Only run Wokwi simualtions in esp-rs repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           run: /bin/bash /home/esp/workspace/.devcontainer/test.sh ${{ matrix.project.path }}
 
       - name: Wokwi CI check
-        if: matrix.project.name == 'button-interrupt' || matrix.project.name == 'http-client' || matrix.project.name == 'hardware-check'
+        if: (matrix.project.name == 'button-interrupt' || matrix.project.name == 'http-client' || matrix.project.name == 'hardware-check') && github.actor == 'esp-rs'
         uses: wokwi/wokwi-ci-action@v1
         with:
           token: ${{ secrets.WOKWI_CLI_TOKEN }}

--- a/.github/workflows/wokwi_projects.yml
+++ b/.github/workflows/wokwi_projects.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   wokwi-check:
     name: ${{ matrix.project.name }}
+    if: github.actor == 'esp-rs'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Running any simulation outside the `esp-rs` org will result in failure due to the `WOKWI_CLI` token not being set