### PR TITLE
Whats the usage difference between EspMqttClient::new and EspMqttClient::new_cb ?

### DIFF
--- a/intro/mqtt/exercise/examples/solution_publ.rs
+++ b/intro/mqtt/exercise/examples/solution_publ.rs
@@ -80,7 +80,7 @@ fn main() -> Result<()> {
     // Your Code:
 
     // 1. Create a client with default configuration and empty handler
-    let mut client = EspMqttClient::new(&broker_url, &mqtt_config, move |_message_event| {
+    let mut client = EspMqttClient::new_cb(&broker_url, &mqtt_config, move |_message_event| {
         // ... your handler code here - leave this empty for now
         // we'll add functionality later in this chapter
     })?;

--- a/intro/mqtt/exercise/examples/solution_publ_rcv.rs
+++ b/intro/mqtt/exercise/examples/solution_publ_rcv.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
 
     // 1. Create a client with default configuration and empty handler
     let mut client =
-        EspMqttClient::new(
+        EspMqttClient::new_cb(
             &broker_url,
             &mqtt_config,
             move |message_event| match message_event {


### PR DESCRIPTION
**TLDR: I want to know when should I be using `EspMqttClient::new` and `EspMqttClient::new_cb` ?** Also I believe mqtt example should be updated.

[documentation reference](https://docs.esp-rs.org/esp-idf-svc/esp_idf_svc/mqtt/client/struct.EspMqttClient.html).
- using `EspMqttClient::new` returns `Result<(Self, EspMqttConnection), EspError>`
- while using `EspMqttClient::new_cb` returns `Result<Self, EspError>`

**Note**: I am using xtensa-esp32-.

Following the given [mqtt example](https://github.com/esp-rs/std-training/blob/main/intro/mqtt/exercise/examples/solution_publ.rs) I am assuming that I need to use `EspMqttClient::new_cb` version. Which has been working as expected. 
Here is my code snippet:
```
let mut mqtt_client = EspMqttClient::new_cb(&broker_url, &mqtt_config, move |_msg| {})?;
```

However, when I try to use the other varient `EspMqttClient::new` nothing is getting published to the mqtt broker, even though I haven't changed the publishing method.
Here is my code snippet:
```
let (mut mqtt_client, _mqtt_connection) = EspMqttClient::new(&broker_url, &mqtt_config)?;
```

**What am I supposed to do with `_mqtt_connection`?**

For reference, here is complete code snippet;
```
let mqtt_config = MqttClientConfiguration::default();
let mut mqtt_client = EspMqttClient::new_cb(&broker_url, &mqtt_config, move |_msg| {})?;

let payload: &[u8] = &[];
mqtt_client.publish("home/default", QoS::AtLeastOnce, true, payload)?;
```


**Suggestion:**
The example defines the new client as follows,
`
let mut client = EspMqttClient::new(&broker_url, &mqtt_config, move |_message_event| {})?;
`
but the function has been updated to use `EspMqttClient::new_cb` instead for `EspMqttClient::new`. 
Updated code:
`
let mut mqtt_client = EspMqttClient::new_cb(&broker_url, &mqtt_config, move |_message_event| {})?;
` 

PS: This is literally my first bug report/pull request, so please let me know if I need to provide any additional information or if there are any issues with my report.