### PR TITLE
Update training

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   // "build": {
   //   "dockerfile": "Dockerfile",
   //   "args": {
-  //     "NIGHTLY_VERSION": "nightly-2024-06-30"
+  //     "NIGHTLY_VERSION": "nightly-2025-01-01"
   //   }
   // },
   "customizations": {

--- a/advanced/button-interrupt/.cargo/config.toml
+++ b/advanced/button-interrupt/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/advanced/button-interrupt/Cargo.toml
+++ b/advanced/button-interrupt/Cargo.toml
@@ -21,9 +21,9 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow      = "=1.0.86"
-esp-idf-svc = "=0.49.0"
+anyhow      = "=1.0.95"
+esp-idf-svc = "=0.50.1"
 rgb-led     = { path = "../../common/lib/rgb-led" }
 
 [build-dependencies]
-embuild = "=0.32.0"
+embuild = "=0.33.0"

--- a/advanced/button-interrupt/rust-toolchain.toml
+++ b/advanced/button-interrupt/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/advanced/i2c-driver/.cargo/config.toml
+++ b/advanced/i2c-driver/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/advanced/i2c-driver/Cargo.toml
+++ b/advanced/i2c-driver/Cargo.toml
@@ -20,9 +20,9 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow       = "=1.0.86"
+anyhow       = "=1.0.95"
 embedded-hal = "=0.2.7"
-esp-idf-svc  = "=0.49.0"
+esp-idf-svc  = "=0.50.1"
 
 [build-dependencies]
-embuild = "=0.32.0"
+embuild = "=0.33.0"

--- a/advanced/i2c-driver/rust-toolchain.toml
+++ b/advanced/i2c-driver/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/advanced/i2c-sensor-reading/.cargo/config.toml
+++ b/advanced/i2c-sensor-reading/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/advanced/i2c-sensor-reading/Cargo.toml
+++ b/advanced/i2c-sensor-reading/Cargo.toml
@@ -20,13 +20,13 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow       = "=1.0.86"
+anyhow       = "=1.0.95"
 embedded-hal = "=0.2.7"
-esp-idf-svc  = "=0.49.0"
+esp-idf-svc  = "=0.50.1"
 icm42670     = "=0.1.1"
 lis3dh       = "=0.4.2"
 shared-bus   = "=0.3.1"
 shtcx        = "=0.11.0"
 
 [build-dependencies]
-embuild = "=0.32.0"
+embuild = "=0.33.0"

--- a/advanced/i2c-sensor-reading/rust-toolchain.toml
+++ b/advanced/i2c-sensor-reading/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/book/src/03_2_cargo_generate.md
+++ b/book/src/03_2_cargo_generate.md
@@ -54,7 +54,7 @@ ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" } # add this line
 
 ```toml
 [toolchain]
-channel = "nightly-2024-06-30" # change this line
+channel = "nightly-2025-01-01" # change this line
 ```
 
 ✅ Run your project by using the following command out of the `hello-world` directory.

--- a/common/lib/get-uuid/Cargo.toml
+++ b/common/lib/get-uuid/Cargo.toml
@@ -8,8 +8,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-anyhow = "=1.0.86"
+anyhow = "=1.0.95"
 
 [build-dependencies]
-anyhow = "=1.0.86"
+anyhow = "=1.0.95"
 uuid   = { version = "=1.9.1", features = ["v4"] }

--- a/common/lib/mqtt-messages/Cargo.toml
+++ b/common/lib/mqtt-messages/Cargo.toml
@@ -8,4 +8,4 @@ authors = [
 edition = "2021"
 
 [dependencies]
-rgb = "=0.8.40"
+rgb = "=0.8.50"

--- a/common/lib/rgb-led/.cargo/config.toml
+++ b/common/lib/rgb-led/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/common/lib/rgb-led/Cargo.toml
+++ b/common/lib/rgb-led/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
 
 [dependencies]
-anyhow      = "=1.0.86"
-esp-idf-svc = "=0.49.0"
+anyhow      = "=1.0.95"
+esp-idf-svc = "=0.50.1"
+esp-idf-hal ={ version = "=0.45.0", features = ["rmt-legacy"] }
 log         = "=0.4.22"
 rgb         = "0.8.29"
 
 [build-dependencies]
-embuild = "=0.32.0"
+embuild = "=0.33.0"

--- a/common/lib/rgb-led/rust-toolchain.toml
+++ b/common/lib/rgb-led/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/common/lib/rgb-led/src/lib.rs
+++ b/common/lib/rgb-led/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use core::time::Duration;
-use esp_idf_svc::hal::{
+use esp_idf_hal::{
     gpio::OutputPin,
     peripheral::Peripheral,
     rmt::{config::TransmitConfig, FixedLengthSignal, PinState, Pulse, RmtChannel, TxRmtDriver},

--- a/common/lib/wifi/.cargo/config.toml
+++ b/common/lib/wifi/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/common/lib/wifi/Cargo.toml
+++ b/common/lib/wifi/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
 
 [dependencies]
-anyhow      = "=1.0.86"
-esp-idf-svc = "=0.49.0"
+anyhow      = "=1.0.95"
+esp-idf-svc = "=0.50.1"
 log         = "=0.4.22"
 
 [build-dependencies]
-embuild = "=0.32.0"
+embuild = "=0.33.0"
 
 [dev-dependencies]
 toml-cfg = "=0.1.3"

--- a/common/lib/wifi/rust-toolchain.toml
+++ b/common/lib/wifi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/intro/hardware-check/.cargo/config.toml
+++ b/intro/hardware-check/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std = ["std", "panic_abort"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/intro/hardware-check/Cargo.toml
+++ b/intro/hardware-check/Cargo.toml
@@ -20,13 +20,13 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow      = "=1.0.86"
-esp-idf-svc = "=0.49.0"
+anyhow      = "=1.0.95"
+esp-idf-svc = "=0.50.1"
 log         = "=0.4.22"
 rgb-led     = { path = "../../common/lib/rgb-led" }
 toml-cfg    = "=0.1.3"
 wifi        = { path = "../../common/lib/wifi" }
 
 [build-dependencies]
-embuild  = "=0.32.0"
+embuild  = "=0.33.0"
 toml-cfg = "=0.1.3"

--- a/intro/hardware-check/rust-toolchain.toml
+++ b/intro/hardware-check/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/intro/http-client/.cargo/config.toml
+++ b/intro/http-client/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/intro/http-client/Cargo.toml
+++ b/intro/http-client/Cargo.toml
@@ -20,12 +20,12 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow       = "=1.0.86"
-embedded-svc = "=0.28.0"
-esp-idf-svc  = "=0.49.0"
+anyhow       = "=1.0.95"
+embedded-svc = "=0.28.1"
+esp-idf-svc  = "=0.50.1"
 toml-cfg     = "=0.1.3"
 wifi         = { path = "../../common/lib/wifi" }
 
 [build-dependencies]
-embuild  = "=0.32.0"
+embuild  = "=0.33.0"
 toml-cfg = "=0.1.3"

--- a/intro/http-client/rust-toolchain.toml
+++ b/intro/http-client/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/intro/http-server/.cargo/config.toml
+++ b/intro/http-server/.cargo/config.toml
@@ -6,14 +6,14 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -23,7 +23,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/intro/http-server/Cargo.toml
+++ b/intro/http-server/Cargo.toml
@@ -20,13 +20,13 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow       = "=1.0.86"
-embedded-svc = "=0.28.0"
-esp-idf-svc  = "=0.49.0"
+anyhow       = "=1.0.95"
+embedded-svc = "=0.28.1"
+esp-idf-svc  = "=0.50.1"
 shtcx        = "=1.0.0"
 toml-cfg     = "=0.1.3"
 wifi         = { path = "../../common/lib/wifi" }
 
 [build-dependencies]
-embuild  = "=0.32.0"
+embuild  = "=0.33.0"
 toml-cfg = "=0.1.3"

--- a/intro/http-server/rust-toolchain.toml
+++ b/intro/http-server/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]

--- a/intro/mqtt/exercise/.cargo/config.toml
+++ b/intro/mqtt/exercise/.cargo/config.toml
@@ -6,15 +6,15 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std          = ["panic_abort", "std"]
 
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.2.2)
-ESP_IDF_VERSION = { value = "tag:v5.2.2" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF (v5.3.2)
+ESP_IDF_VERSION = { value = "tag:v5.3.2" }
 
 # These configurations will pick up your custom "sdkconfig.release", "sdkconfig.debug" or "sdkconfig.defaults[.*]" files
 # that you might put in the root of the project
@@ -24,7 +24,6 @@ ESP_IDF_VERSION = { value = "tag:v5.2.2" }
 #ESP_IDF_SDKCONFIG = { value = "./sdkconfig.debug", relative = true }
 ESP_IDF_SDKCONFIG_DEFAULTS = { value = "./sdkconfig.defaults", relative = true }
 # ESP-IDF will be installed in ~/.espressif so it can be reused across the different examples.
-# See also https://github.com/esp-rs/esp-idf-sys#esp_idf_tools_install_dir-esp_idf_tools_install_dir
+# See also https://github.com/esp-rs/esp-idf-sys/blob/master/BUILD-OPTIONS.md#esp_idf_tools_install_dir-esp_idf_tools_install_dir
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" }
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+

--- a/intro/mqtt/exercise/Cargo.toml
+++ b/intro/mqtt/exercise/Cargo.toml
@@ -20,9 +20,9 @@ debug     = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
-anyhow        = "=1.0.86"
-embedded-svc  = "=0.28.0"
-esp-idf-svc   = "=0.49.0"
+anyhow        = "=1.0.95"
+embedded-svc  = "=0.28.1"
+esp-idf-svc   = "=0.50.1"
 get-uuid      = { path = "../../../common/lib/get-uuid" }
 log           = "=0.4.22"
 mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
@@ -32,5 +32,5 @@ toml-cfg      = "=0.1.3"
 wifi          = { path = "../../../common/lib/wifi" }
 
 [build-dependencies]
-embuild  = "=0.32.0"
+embuild  = "=0.33.0"
 toml-cfg = "=0.1.3"

--- a/intro/mqtt/exercise/rust-toolchain.toml
+++ b/intro/mqtt/exercise/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "nightly-2024-06-30"
+channel    = "nightly-2025-01-01"
 components = ["rust-src"]


### PR DESCRIPTION
- Update esp-idf version to `v5.3.2`
- Update nightly version to `2025-01-01`
- Update esp-idf-* crates:
  - `esp-idf-svc = "=0.50.1"`
  - `embuild = "=0.33.0"`
- Update other deps 